### PR TITLE
Implement power operation for loss composition

### DIFF
--- a/captum/optim/_core/loss.py
+++ b/captum/optim/_core/loss.py
@@ -78,8 +78,23 @@ class Loss(ABC):
                 "Can only divide by int or float. Received type " + str(type(other))
             )
 
+    def __pow__(self, other):
+        if isinstance(other, (int, float)):
+
+            def loss_fn(module):
+                return self(module) ** other
+
+            return CompositeLoss(loss_fn, name=self.__name__, target=self.target)
+        else:
+            raise TypeError(
+                "Can only use int or float powers. Received type " + str(type(other))
+            )
+
     def __rmul__(self, other):
         return self.__mul__(other)
+
+    def __rpow__(self, other):
+        return self.__pow__(other)
 
     def __radd__(self, other):
         return self.__add__(other)


### PR DESCRIPTION
* The cosine objectives in Lucid / Lucent have a power parameter, but I omitted that in Captum. Adding the power operation lets us do the same thing without needing to add the parameter to the cosine objectives.

This should now be possible I think:

```
loss_fn = optimviz.loss.ChannelActivation(target, 5) + optimviz.loss.Diversity(target) ** 5
```

I think that I implemented it correctly, but please double check to make sure.