### PR TITLE
Example for batch specific targeting

### DIFF
--- a/captum/optim/_core/loss.py
+++ b/captum/optim/_core/loss.py
@@ -158,6 +158,7 @@ class LayerActivation(Loss):
     Maximize activations at the target layer.
     """
 
+    @batch_target_wrapper
     def __call__(self, targets_to_values: ModuleOutputMapping) -> torch.Tensor:
         return targets_to_values[self.target]
 

--- a/captum/optim/_core/loss.py
+++ b/captum/optim/_core/loss.py
@@ -174,6 +174,7 @@ class ChannelActivation(Loss):
         self.target = target
         self.channel_index = channel_index
 
+    @batch_target_wrapper
     def __call__(self, targets_to_values: ModuleOutputMapping) -> torch.Tensor:
         activations = targets_to_values[self.target]
         assert activations is not None


### PR DESCRIPTION
The code adds a `target_batch` variable to all loss function classes. The code may be able to be improved, and you can just copy it to your branch instead of merging this PR. I've tested the code to make sure it works correctly as well.